### PR TITLE
Temporary fix for broken dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ node_modules/@financial-times/n-gage/index.mk:
 -include node_modules/@financial-times/n-gage/index.mk
 
 build:
-	# temp fix for bug in @types/node@10.0.0 - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342
-	npm i @types/node@9.6.7
 	rm -rf dist && rm -rf public
 	tsc --p tsconfig.json
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ node_modules/@financial-times/n-gage/index.mk:
 
 build:
 	# temp fix for bug in @types/node@10.0.0 - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342
-	npm i --save-dev @types/node@9.6.7
+	npm i @types/node@9.6.7
 	rm -rf dist && rm -rf public
 	tsc --p tsconfig.json
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ node_modules/@financial-times/n-gage/index.mk:
 -include node_modules/@financial-times/n-gage/index.mk
 
 build:
+	# temp fix for bug in @types/node@10.0.0 - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342
+	npm i --save-dev @types/node@9.6.7
 	rm -rf dist && rm -rf public
 	tsc --p tsconfig.json
 

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "build": "tsc",
     "clean": "rm -r ./dist ./public",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg"
+  },
+  "dependencies": {
+    "@types/node": "9.6.7"
   }
 }


### PR DESCRIPTION
`@types/node@10.0.0` is breaking our build ([issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342)).

This is a temporary fix that simply downgrades `@types/node` to the most recent working version.

This fix should be removed once the upstream package is fixed. Will create an issue so this is kept track of.