### PR TITLE
Set `aria-hidden` to true when popup is closed

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -59,6 +59,8 @@ class LiveChatPopup extends LiveChat {
             this.popup.setAttribute('data-n-sliding-popup-visible', 'true');
             this.closeButton.onclick = () => {
                 this.popup.removeAttribute('data-n-sliding-popup-visible');
+                this.popup.setAttribute('aria-hidden', 'true');
+
                 if (callbacks && callbacks.dismiss) {
                     callbacks.dismiss();
                 }

--- a/templates/partials/popup.html
+++ b/templates/partials/popup.html
@@ -1,4 +1,4 @@
-<div id="liveAgentPopup" class="n-sliding-popup n-live-agent__popup" data-n-component="n-sliding-popup" data-n-sliding-popup-position="bottom right">
+<div id="liveAgentPopup" class="n-sliding-popup n-live-agent__popup" data-n-component="n-sliding-popup" data-n-sliding-popup-position="bottom right" aria-hidden="false">
 	<div class="n-live-agent__popup-cta">
 		Need help?
 		<button id="liveAgentButton" class="n-live-agent__popup-button" data-trackable="livechat-openChatWindow">


### PR DESCRIPTION
Currently when a user closes the popup, it disappears from the screen but is still picked up by the screen reader. This is because all we do is change the popup's opacity and essentially make it invisible when closed. This PR sets `aria-hidden` to true so we don't confuse screen reader users. The reason why we use `aria-hidden` over `display: none` is because the popup is animated and it would be a lot more complicated to use the later.

DAC ticket: https://trello.com/c/aQqSISwt/160-bleedthrough-issue-id-dacbleedthrough01 🐿 v2.12.5