### PR TITLE
Upgrade to React 17 + some chores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,16 @@ build:
 
 build-production: build
 
-build-demo: build
+build-demo:
+	make build
 	# transpiling demo app
 	webpack --config demos/webpack.config.js
 	# building styles
 	sass demos/scss/demo.scss public/main.css --load-path node_modules
 	@$(DONE)
 
-demo: build-demo
+demo: .env
+	make build-demo
 	node demos/app
 
 a11y: build-demo

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ build:
 	sass src/scss/main.scss --load-path node_modules
 	@$(DONE)
 
-build-production: build
+build-production:
+	make build
 
 build-demo:
 	make build
@@ -21,11 +22,13 @@ build-demo:
 	sass demos/scss/demo.scss public/main.css --load-path node_modules
 	@$(DONE)
 
-demo: .env
+demo:
+	make .env
 	make build-demo
 	node demos/app
 
-a11y: build-demo
+a11y:
+	make build-demo
 	@node .pa11yci.js
 	@PA11Y=true node demos/app
 	@$(DONE)

--- a/demos/app.js
+++ b/demos/app.js
@@ -1,6 +1,8 @@
 require('sucrase/register');
 const express = require('@financial-times/n-express');
-const { PageKitReactJSX } = require('@financial-times/dotcom-server-react-jsx');
+const ReactDOM = require('react-dom/server');
+
+const demoTemplate = require('./views/demo.jsx')
 
 const app = express({
 	name: 'public',
@@ -15,11 +17,6 @@ const app = express({
 
 app.use(express.static('public'));
 
-app.set('views', `${__dirname}/views`);
-app.set('view engine', '.html');
-
-app.engine('.jsx', new PageKitReactJSX().engine);
-
 const salesforceConfig = {
 	deploymentId: process.env.SALESFORCE_DEPLOYMENT_ID,
 	organisationId: process.env.SALESFORCE_ORGANISATION_ID,
@@ -28,17 +25,21 @@ const salesforceConfig = {
 };
 
 app.get('/popup', (req, res) => {
-	res.render('demo.jsx', {
+	const page = demoTemplate.default({
 		style: 'popup',
 		salesforceConfig
-	});
+	})
+
+	res.send(ReactDOM.renderToStaticMarkup(page))
 });
 
 app.get('/inline', (req, res) => {
-	res.render('demo.jsx', {
+	const page = demoTemplate.default({
 		style: 'inline',
 		salesforceConfig
-	});
+	})
+
+	res.send(ReactDOM.renderToStaticMarkup(page))
 });
 
 function runPa11yTests () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@babel/core": "^7.8.3",
         "@babel/plugin-transform-react-jsx": "^7.8.3",
         "@babel/preset-env": "^7.8.3",
-        "@financial-times/dotcom-server-react-jsx": "7.0.0",
         "@financial-times/dotcom-ui-shell": "7.0.0",
         "@financial-times/n-express": "^22.4.1",
         "@financial-times/n-gage": "^8.2.0",
@@ -28,7 +27,8 @@
         "babel-loader": "^8.0.6",
         "check-engine": "^1.10.1",
         "pa11y-ci": "^2.1.1",
-        "react": "^16.12.0",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0",
         "rollup": "^1.29.1",
         "rollup-plugin-babel": "^4.3.3",
         "sass": "^1.51.0",
@@ -48,7 +48,7 @@
         "@financial-times/o-icons": "^7.2.1",
         "@financial-times/o-typography": "^7.3.2",
         "@financial-times/o-visual-effects": "^4.2.0",
-        "react": "^16.12.0"
+        "react": "^17.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1537,21 +1537,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@financial-times/dotcom-server-react-jsx": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/dotcom-server-react-jsx/-/dotcom-server-react-jsx-7.0.0.tgz",
-      "integrity": "sha512-U3Fp/j4aRtWcjFHINmkaxCba5ry6KKZgkz59Lpcw2Dfh0qErAKFG4MhheuYqdwFCtrJsaoMEYwR2QCxpgl7biA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6"
-      },
-      "engines": {
-        "node": ">= 14.0.0",
-        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/dotcom-ui-app-context": {
@@ -9876,30 +9861,30 @@
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "16.14.0",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "^16.14.0"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-is": {
@@ -10588,8 +10573,9 @@
       "dev": true
     },
     "node_modules/scheduler": {
-      "version": "0.19.1",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -12654,6 +12640,7 @@
     },
     "node_modules/typescript": {
       "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true,
       "bin": {
@@ -15145,16 +15132,6 @@
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@financial-times/dotcom-server-react-jsx": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/dotcom-server-react-jsx/-/dotcom-server-react-jsx-7.0.0.tgz",
-      "integrity": "sha512-U3Fp/j4aRtWcjFHINmkaxCba5ry6KKZgkz59Lpcw2Dfh0qErAKFG4MhheuYqdwFCtrJsaoMEYwR2QCxpgl7biA==",
-      "dev": true,
-      "requires": {
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6"
       }
     },
     "@financial-times/dotcom-ui-app-context": {
@@ -21518,24 +21495,24 @@
       }
     },
     "react": {
-      "version": "16.14.0",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.20.2"
       }
     },
     "react-is": {
@@ -22060,8 +22037,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.19.1",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -23634,6 +23612,7 @@
     },
     "typescript": {
       "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
       "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "sass": "^1.51.0",
         "snyk": "^1.167.2",
         "sucrase": "^3.12.1",
-        "typescript": "^3.7.2",
+        "typescript": "^4.0.0",
         "webpack": "^4.16.0",
         "webpack-cli": "^3.0.8"
       },
@@ -12639,9 +12639,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -23611,9 +23611,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sass": "^1.51.0",
     "snyk": "^1.167.2",
     "sucrase": "^3.12.1",
-    "typescript": "^3.7.2",
+    "typescript": "^4.0.0",
     "webpack": "^4.16.0",
     "webpack-cli": "^3.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@babel/core": "^7.8.3",
     "@babel/plugin-transform-react-jsx": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
-    "@financial-times/dotcom-server-react-jsx": "7.0.0",
     "@financial-times/dotcom-ui-shell": "7.0.0",
     "@financial-times/n-express": "^22.4.1",
     "@financial-times/n-gage": "^8.2.0",
@@ -22,7 +21,8 @@
     "babel-loader": "^8.0.6",
     "check-engine": "^1.10.1",
     "pa11y-ci": "^2.1.1",
-    "react": "^16.12.0",
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0",
     "rollup": "^1.29.1",
     "rollup-plugin-babel": "^4.3.3",
     "sass": "^1.51.0",
@@ -53,7 +53,7 @@
     "@financial-times/o-icons": "^7.2.1",
     "@financial-times/o-typography": "^7.3.2",
     "@financial-times/o-visual-effects": "^4.2.0",
-    "react": "^16.12.0"
+    "react": "^17.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
### Main Goal

Upgrade to use React 17 

### Extra chores

1. Remove the use of `dotcom-server-react-jsx` in favour of `react-dom` - this needed to be done because `dotcom-server-react-jsx` uses React 16 but also there is little/no value in using this package vs the standard react-dom
1. Improve the running of demos so the env vars are fetched if you haven't run the system before - took me awhile to figure out why the demos weren't working when I ran the system the first time
1. Upgrade Typescript to v4 because v3 is causing build errors as it tried to build `.d.ts` files from node_modules