### PR TITLE
Downgrade the peer dependency for react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@financial-times/o-icons": "^7.2.1",
         "@financial-times/o-typography": "^7.3.2",
         "@financial-times/o-visual-effects": "^4.2.0",
-        "react": "^17.0.0"
+        "react": "^16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@financial-times/o-icons": "^7.2.1",
     "@financial-times/o-typography": "^7.3.2",
     "@financial-times/o-visual-effects": "^4.2.0",
-    "react": "^17.0.0"
+    "react": "^16.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
There is nothing in this component that needs react 17 and we have consuming apps that can't currently upgrade to 17 so we want to drop this back down