### PR TITLE
ACC-2127: fix url path

### DIFF
--- a/src/js/browser.ts
+++ b/src/js/browser.ts
@@ -82,7 +82,7 @@ class LiveChat {
 								const LIVE_CHAT_STAGING_HOST = 'https://ip-chatterbox-client-staging.herokuapp.com';
 								const LIVE_CHAT_PROD_HOST = 'https://d.la1-c1cs-iad.salesforceliveagent.com'
 								const baseUrl: string = this.flags.get('liveChatStaging') ? LIVE_CHAT_STAGING_HOST : LIVE_CHAT_PROD_HOST;
-								const url: string = `${baseUrl}${this.config.buttonReference}/${this.config.deploymentId}`;
+								const url: string = `${baseUrl}/${this.config.buttonReference}/${this.config.deploymentId}`;
 								window.open(url, 'FT Live Chat', 'height=474px, width=467px')
 							} else {
 								liveagent.startChat(this.config.buttonReference);


### PR DESCRIPTION
##Ticket
[ACC-2127](https://financialtimes.atlassian.net/browse/ACC-2127)
Related PR: https://github.com/Financial-Times/n-live-chat/pull/93
### Description
we should change the stagging url depending on liveChatStaging flag but we miss '/' between baseUrl and buttonReference