### PR TITLE
ACC-2235: create new liveChat flag to enable or disable chat

### DIFF
--- a/src/js/browser.ts
+++ b/src/js/browser.ts
@@ -53,7 +53,7 @@ class LiveChat {
 	}
 
 	initializer(onInit?: Function): Function {
-		if(this.flags.get('liveChatStaging')) {
+		if(this.flags.get('liveChat')) {
 			return (callbacks?: LiveChatCallbacks | null, options?: LiveChatOptions | null): void => {
 				let script: HTMLScriptElement = document.createElement('script');
 				script.src = `${this.config.host}/content/g/js/41.0/deployment.js`;


### PR DESCRIPTION
### Description
The team that runs the liveChat is doing a big migration soon! They want to have a flag to turn off the liveChat over a few hours so they can ensure no real users connect to the chat, even though some agents will be online testing things.
### Ticket
[ACC-2235](https://financialtimes.atlassian.net/browse/ACC-2235)

[ACC-2235]: https://financialtimes.atlassian.net/browse/ACC-2235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ