### PR TITLE
ingest sliding popup into live-chat

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(ts|tsx)?$': 'ts-jest',
+    "^.+\\.(js|jsx)$": "babel-jest",
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@financial-times/n-sliding-popup": "4.0.0",
         "n-ui-foundations": "^9.0.0",
         "prop-types": "^15.7.2"
       },
@@ -28,6 +27,7 @@
         "@types/typescript": "^2.0.0",
         "babel-loader": "^8.0.6",
         "check-engine": "^1.10.1",
+        "expect.js": "^0.3.1",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "pa11y-ci": "^2.1.1",
@@ -50,6 +50,7 @@
       "peerDependencies": {
         "@financial-times/o-buttons": "^7.5.0",
         "@financial-times/o-colors": "^6.4.2",
+        "@financial-times/o-grid": "^6.1.5",
         "@financial-times/o-icons": "^7.2.1",
         "@financial-times/o-typography": "^7.3.2",
         "@financial-times/o-visual-effects": "^4.2.0",
@@ -2028,20 +2029,6 @@
       "engines": {
         "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
-      }
-    },
-    "node_modules/@financial-times/n-sliding-popup": {
-      "version": "4.0.0",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
-      },
-      "peerDependencies": {
-        "@financial-times/o-colors": "^6.4.2",
-        "@financial-times/o-grid": "^6.1.5",
-        "@financial-times/o-icons": "^7.2.1"
       }
     },
     "node_modules/@financial-times/o-brand": {
@@ -6774,6 +6761,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha512-okDF/FAPEul1ZFLae4hrgpIqAeapoo5TRdcg/lD0iN9S3GWrBFIJwNezGH1DMtIz+RxU4RrFmMq7WUUvDg3J6A==",
+      "dev": true
     },
     "node_modules/express": {
       "version": "4.18.2",
@@ -19690,10 +19683,6 @@
         "raven": "^2.3.0"
       }
     },
-    "@financial-times/n-sliding-popup": {
-      "version": "4.0.0",
-      "requires": {}
-    },
     "@financial-times/o-brand": {
       "version": "4.2.1",
       "peer": true
@@ -23059,6 +23048,12 @@
         "jest-message-util": "^29.5.0",
         "jest-util": "^29.5.0"
       }
+    },
+    "expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha512-okDF/FAPEul1ZFLae4hrgpIqAeapoo5TRdcg/lD0iN9S3GWrBFIJwNezGH1DMtIz+RxU4RrFmMq7WUUvDg3J6A==",
+      "dev": true
     },
     "express": {
       "version": "4.18.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/typescript": "^2.0.0",
     "babel-loader": "^8.0.6",
     "check-engine": "^1.10.1",
+    "expect.js": "^0.3.1",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "pa11y-ci": "^2.1.1",
@@ -49,13 +50,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "@financial-times/n-sliding-popup": "4.0.0",
     "n-ui-foundations": "^9.0.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "@financial-times/o-buttons": "^7.5.0",
     "@financial-times/o-colors": "^6.4.2",
+    "@financial-times/o-grid": "^6.1.5",
     "@financial-times/o-icons": "^7.2.1",
     "@financial-times/o-typography": "^7.3.2",
     "@financial-times/o-visual-effects": "^4.2.0",

--- a/sliding-popup/main.js
+++ b/sliding-popup/main.js
@@ -1,0 +1,13 @@
+import SlidingPopup from './sliding-popup';
+
+const constructAll = function() {
+	const els = document.querySelectorAll('[data-n-component="n-sliding-popup"]');
+	for(let i = 0; i < els.length; i+=1) {
+		SlidingPopup.init(els[i]);
+	}
+	document.removeEventListener('o.DOMContentLoaded', constructAll);
+};
+
+document.addEventListener('o.DOMContentLoaded', constructAll);
+
+export default SlidingPopup;

--- a/sliding-popup/main.scss
+++ b/sliding-popup/main.scss
@@ -1,0 +1,74 @@
+@import '@financial-times/o-colors/main';
+@import '@financial-times/o-icons/main';
+@import '@financial-times/o-grid/main';
+
+.n-sliding-popup {
+  position: fixed;
+  display: inline-block;
+  opacity: 0;
+  z-index: 1000;
+  transition: all .4s ease-in-out, opacity .6s ease-in;
+  padding: 14px;
+  box-shadow: 0px 0px 17px 4px rgba(0, 0, 0, 0.11);
+  border: 2px solid oColorsByName('black-20');
+  border-radius: 6px;
+  background: white;
+
+  &[data-n-sliding-popup-visible] {
+    opacity: 1;
+  }
+
+  @include oGridRespondTo($until: M) {
+    right: 0;
+    left: 0;
+  }
+
+  @include oGridRespondTo($from: M) {
+
+    &[data-n-sliding-popup-position*="left"] {
+      left: 1vh;
+    }
+
+    &[data-n-sliding-popup-position*="right"] {
+      right: 1vh;
+    }
+  }
+
+  &[data-n-sliding-popup-position*="bottom"] {
+    bottom: -50vh;
+    &[data-n-sliding-popup-visible] {
+      bottom: 1vh;
+    }
+  }
+
+  &[data-n-sliding-popup-position*="top"] {
+    top: -50vh;
+    &[data-n-sliding-popup-visible] {
+      top: 1vh;
+    }
+  }
+
+  .n-sliding-popup-close {
+    @include oIconsContent(
+      $icon-name: 'cross',
+      $color: oColorsByName('black-70'),
+      $size: 30,
+      $iconset-version: 1
+    );
+    border: 0;
+    position: absolute;
+    right: 6px;
+    top: 6px;
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  .n-sliding-popup-close-label {
+    position: absolute;
+    left: -10000px;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+  }
+
+}

--- a/sliding-popup/sliding-popup-readme.md
+++ b/sliding-popup/sliding-popup-readme.md
@@ -1,0 +1,98 @@
+
+This used to be an origami component, but has always been denoted as "experimental". In April 2023 we did an inventory of the repos we own and we talked to the Origami team about this becoming an official component. However, this wasn't possible due to the first question of the process: "is it going to be used in more than one place". n-sliding-popup was only used by n-live-chat (which at the time of writing is used in next-profile, next-retention, and next-subscribe). The consensus was that we should move n-sliding-popup into n-live-chat to reduce the number of repos we need to maintain. You can find the original repo at https://github.com/Financial-Times/n-sliding-popup.
+
+The sliding popup is designed to allow a wrapped component to slide up from the bottom of the page when triggered, providing an interactive user experience
+----
+
+## Usage
+
+Create a div that looks like this:
+
+```html
+<div class="n-sliding-popup" data-n-component="n-sliding-popup" data-n-sliding-popup-position="bottom right">
+</div>
+```
+
+You can also create an instance of this with the following:
+
+```js
+new SlidingPopup('#some-el-which-is-a-sliding-popup');
+```
+
+### Opening the Popup
+
+If you have a `SlidingPopup` instance, you can call `.open()` on the instance:
+
+```js
+sp = new SlidingPopup('#some-el-which-is-a-sliding-popup');
+sp.open();
+```
+
+If you do not, then you'll need to set the `data-n-sliding-popup-visible`
+attribute manually:
+
+```js
+el = document.querySelector('#some-el-which-is-a-sliding-popup');
+el.setAttribute('data-n-sliding-popup-visible', 'true');
+```
+
+### Closing the Popup
+
+You can add a close button by making a sub-element with `data-n-component="n-sliding-popup-close"`:
+
+```html
+<div class="n-sliding-popup" data-n-component="n-sliding-popup" data-n-sliding-popup-position="bottom right">
+  <button class="n-sliding-popup-close" data-n-component="n-sliding-popup-close">
+    <span class="n-sliding-popup-close-label">Close</span>
+  </button>
+</div>
+```
+
+This will Just Work™ and close the popup on click. Again, the button must have
+`data-n-component="n-sliding-popup-close"` for functionality. Be sure to add the
+`n-sliding-popup-close` class for the CSS styles. `n-sliding-popup-close-label`
+can be used to style text that is visible only to screen readers.
+
+If you want your own button, then it should use `SlidingPopup#close`, for example:
+
+```js
+sp = new SlidingPopup('#some-el-which-is-a-sliding-popup');
+sp.close();
+```
+
+You can also simply remove the `data-n-sliding-popup-visible` attribute - but
+this will not fire the additional event handlers described below...
+
+### Doing things on Close
+
+There are 3 ways to add handlers for closing. You can simply add the old-school
+`onClose` attribute to the element:
+
+```js
+el = document.querySelector('#some-el-which-is-a-sliding-popup');
+el.onClose = (event) => {
+  event.detail.target === el;
+  event.detail.instance instanceof SlidingPopup;
+};
+```
+
+`onClose` can also be set on the SlidingPopup el:
+
+```js
+sp = new SlidingPopup('#some-el-which-is-a-sliding-popup');
+sp.onClose = (event) => {
+  event.detail.instance === sp;
+  event.detail.target === sp.el;
+};
+```
+
+Of course the "proper" way to do this is with event listeners, like you would
+normal DOM elements. Just listen for the "close" event on the main component:
+
+```js
+el = document.querySelector('#some-el-which-is-a-sliding-popup');
+el.addEventListener('close', (event) => {
+  event.detail.target === el;
+  event.detail.instance instanceof SlidingPopup;
+});
+```

--- a/sliding-popup/sliding-popup-test.js
+++ b/sliding-popup/sliding-popup-test.js
@@ -1,0 +1,63 @@
+/*global describe, it */
+
+// import expect from 'expect.js';
+
+import SlidingPopup from './sliding-popup';
+
+describe("SlidingPopup", () => {
+	let popup;
+
+	beforeEach(() => {
+		popup = new SlidingPopup();
+	});
+
+	afterEach(() => {
+		popup.close();
+	});
+
+	it('should be defined', () => {
+		expect(SlidingPopup).to.be.a('function');
+	});
+
+	it('should have a static init method', () => {
+		expect(SlidingPopup.init).to.be.a('function');
+	});
+
+	it('should open when the open method is called', () => {
+		popup.open();
+		expect(popup.el.getAttribute('data-n-sliding-popup-visible')).to.equal('true');
+	});
+
+	it('should close when the close method is called', () => {
+		popup.el.setAttribute('data-n-sliding-popup-visible', 'true');
+		popup.close();
+		expect(popup.el.getAttribute('data-n-sliding-popup-visible')).to.equal(null);
+	});
+
+	it('should dispatch a close event when the close method is called', () => {
+		let eventDispatched = false;
+		popup.el.addEventListener('close', () => {
+			eventDispatched = true;
+		});
+		popup.close();
+		expect(eventDispatched).to.equal(true);
+	});
+
+	it('should invoke the onClose callback when the close method is called', () => {
+		let callbackInvoked = false;
+		popup.el.onClose = () => {
+			callbackInvoked = true;
+		};
+		popup.close();
+		expect(callbackInvoked).to.equal(true);
+	});
+
+	it('should invoke the onClose callback on the instance when the close method is called', () => {
+		let callbackInvoked = false;
+		popup.onClose = () => {
+			callbackInvoked = true;
+		};
+		popup.close();
+		expect(callbackInvoked).to.equal(true);
+	});
+});

--- a/sliding-popup/sliding-popup.js
+++ b/sliding-popup/sliding-popup.js
@@ -1,0 +1,56 @@
+/**
+ * A sliding popup component.
+ */
+class SlidingPopup {
+	/**
+	 * Creates a new SlidingPopup instance.
+	 * @param {HTMLElement|string} el - The element or CSS selector to use as the popup.
+	 */
+	constructor(el) {
+	  if (!el) {
+		el = document.querySelector('[data-n-component="n-sliding-popup"]');
+	  } else if (typeof el === 'string') {
+		el = document.querySelector(el);
+	  }
+	  this.el = el;
+	  this.isOpen = false;
+	  el.classList.toggle('n-sliding-popup--active', true);
+	  const close = el.querySelector('[data-n-component="n-sliding-popup-close"]');
+	  if (close) {
+		close.addEventListener('click', () => this.close());
+	  }
+	}
+  
+	/**
+	 * Opens the popup.
+	 */
+	open() {
+	  if (!this.isOpen) {
+		this.el.setAttribute('data-n-sliding-popup-visible', 'true');
+		this.isOpen = true;
+	  }
+	}
+  
+	/**
+	 * Closes the popup.
+	 */
+	close() {
+	  if (this.isOpen) {
+		this.el.removeAttribute('data-n-sliding-popup-visible');
+		const event = new CustomEvent('close', { detail: { target: this.el, instance: this }});
+		this.el.dispatchEvent(event);
+		this.isOpen = false;
+	  }
+	}
+  
+	/**
+	 * Initializes a new SlidingPopup instance on the given element or selector.
+	 * @param {HTMLElement|string} el - The element or CSS selector to use as the popup.
+	 * @returns {SlidingPopup} A new SlidingPopup instance.
+	 */
+	static init(el) {
+	  return new SlidingPopup(el);
+	}
+  }
+  
+  export default SlidingPopup;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -4,8 +4,10 @@ $system-code: 'n-live-chat';
 @import '@financial-times/o-icons/main';
 @import '@financial-times/o-buttons/main';
 @import '@financial-times/o-visual-effects/main';
-@import '@financial-times/n-sliding-popup/main';
+@import '@financial-times/o-grid/main';
 @import 'mixins';
+@import '../../sliding-popup/main.scss';
+
 
 @include nLiveChatInline();
 @include nLiveChatPopup();


### PR DESCRIPTION
TL;DR: n-sliding-popup can't be an origami component, Origami suggested we ingest it into n-live-chat (seeing as it's the only repo that uses it) to save ourselves on maintenance. 

This is a bit of a slap-dash, copy-paste from n-sliding-popup. The demo works locally. I will release as a major, ingest into next-profile and babysit to make sure it still works as it should. 