### PR TITLE
chore: Add support for react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@financial-times/o-icons": "^7.2.1",
     "@financial-times/o-typography": "^7.3.2",
     "@financial-times/o-visual-effects": "^4.2.0",
-    "react": "^16.0.0"
+    "react": "16.x || 17.x"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This PR add support for react 17 so that other teams using react 17 can use the latest version on node 18 without it breaking their estate.