### PR TITLE
Migrate to doppler in toolkit

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,5 +13,4 @@ secret-squirrel.js
 rollup.config.js
 renovate.json
 README.md
-Makefile
 CODEOWNERS

--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -1,7 +1,7 @@
 plugins:
   - '@dotcom-tool-kit/component'
   - '@dotcom-tool-kit/node'
-  - '@dotcom-tool-kit/pa11y'
+  - '@dotcom-tool-kit/jest'
   - '@dotcom-tool-kit/typescript'
   - '@dotcom-tool-kit/webpack'
   - './toolkit/cleanup'
@@ -25,15 +25,15 @@ hooks:
   'run:local':
     - Node
   'test:local':
-    - Pa11y
+    - TypeScriptTest
+    - JestLocal
   'test:ci':
-    - Node
+    - JestCI
 options:
   '@dotcom-tool-kit/node':
     entry: 'demos/app.js'
     ports: [5005]
-  '@dotcom-tool-kit/vault':
-    team: 'next'
-    app: 'n-live-chat'
+  '@dotcom-tool-kit/doppler':
+    project: 'repo_n-live-chat'
   '@dotcom-tool-kit/webpack':
     configPath: 'demos/webpack.config.js'

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ new LiveChatPopup().init(null, options);
 ### Demos
 
 ```sh
-make install .env demo
+npm run start
 ```
 
 - [Inline component demo](http://localhost:5005/inline)(for the purpose of demo this uses the staging environment url)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@babel/plugin-transform-react-jsx": "^7.8.3",
         "@babel/preset-env": "^7.8.3",
         "@dotcom-tool-kit/component": "^4.0.4",
-        "@dotcom-tool-kit/jest": "^3.2.2",
+        "@dotcom-tool-kit/jest": "^3.3.0",
         "@dotcom-tool-kit/logger": "^3.3.0",
         "@dotcom-tool-kit/node": "^3.3.8",
         "@dotcom-tool-kit/pa11y": "^0.5.0",
@@ -36,6 +36,7 @@
         "check-engine": "^1.10.1",
         "dotcom-tool-kit": "^3.3.9",
         "expect.js": "^0.3.1",
+        "husky": "^8.0.3",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "pa11y-ci": "^3.0.1",
@@ -1885,13 +1886,13 @@
       }
     },
     "node_modules/@dotcom-tool-kit/jest": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/jest/-/jest-3.2.2.tgz",
-      "integrity": "sha512-xAr46C7oHBxNSMoB4AGDy9AJt7oc7/TTSP3zhrbVK22/YSd+yRXSpeQVzba8I5f+snKCi0GPQKBg9i2cszJnAw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/jest/-/jest-3.3.0.tgz",
+      "integrity": "sha512-n271yfXlng91kSW/GjoPEJMGCNSLOd3pF0qeg4O5FgTFxp4vjn4/MDRfkUdNmcBBGk4CFIujjpwAdQwaeCOEZw==",
       "dev": true,
       "dependencies": {
-        "@dotcom-tool-kit/logger": "^3.3.0",
-        "@dotcom-tool-kit/types": "^3.4.1",
+        "@dotcom-tool-kit/logger": "^3.3.1",
+        "@dotcom-tool-kit/types": "^3.5.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1904,9 +1905,9 @@
       }
     },
     "node_modules/@dotcom-tool-kit/logger": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/logger/-/logger-3.3.0.tgz",
-      "integrity": "sha512-NQRWKgrqyX45r3bJfb/91lniawPRU1NYQUT0IoeeqhQGxb3zofshjRv8dgxMdsvSwp6TGmrfKgOZExRlpHnqGw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/logger/-/logger-3.3.1.tgz",
+      "integrity": "sha512-GA976JLtnTK4xvDYYuUnAKkByonWO7Nsu8roK1RQ7DMxk8dfC9/vbFidxsaFq3oeFAY2OfTsqtCDdXhwcPxofA==",
       "dev": true,
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -2079,13 +2080,13 @@
       }
     },
     "node_modules/@dotcom-tool-kit/types": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/types/-/types-3.4.1.tgz",
-      "integrity": "sha512-laZf+QpC8WZ02zep4bKU+tk0bfO0fEXIKUNfw6rTzkk2XctaLPj9PcKYqVq3EGPE3Sc/wpqwBkspVrhfEN4xXA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/types/-/types-3.5.0.tgz",
+      "integrity": "sha512-xmQHpqF4nRifgYXpgWkPUsW3GyhzcVR5qNcSjknZTF7ETsnlOWcKRl28VRZFL9FMn8fR5ftq/LgBq0jtvFaiKg==",
       "dev": true,
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
-        "@dotcom-tool-kit/logger": "^3.3.0",
+        "@dotcom-tool-kit/logger": "^3.3.1",
         "semver": "^7.3.7",
         "tslib": "^2.3.1",
         "zod": "^3.20.2"
@@ -7612,6 +7613,21 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -16280,20 +16296,20 @@
       }
     },
     "@dotcom-tool-kit/jest": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/jest/-/jest-3.2.2.tgz",
-      "integrity": "sha512-xAr46C7oHBxNSMoB4AGDy9AJt7oc7/TTSP3zhrbVK22/YSd+yRXSpeQVzba8I5f+snKCi0GPQKBg9i2cszJnAw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/jest/-/jest-3.3.0.tgz",
+      "integrity": "sha512-n271yfXlng91kSW/GjoPEJMGCNSLOd3pF0qeg4O5FgTFxp4vjn4/MDRfkUdNmcBBGk4CFIujjpwAdQwaeCOEZw==",
       "dev": true,
       "requires": {
-        "@dotcom-tool-kit/logger": "^3.3.0",
-        "@dotcom-tool-kit/types": "^3.4.1",
+        "@dotcom-tool-kit/logger": "^3.3.1",
+        "@dotcom-tool-kit/types": "^3.5.0",
         "tslib": "^2.3.1"
       }
     },
     "@dotcom-tool-kit/logger": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/logger/-/logger-3.3.0.tgz",
-      "integrity": "sha512-NQRWKgrqyX45r3bJfb/91lniawPRU1NYQUT0IoeeqhQGxb3zofshjRv8dgxMdsvSwp6TGmrfKgOZExRlpHnqGw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/logger/-/logger-3.3.1.tgz",
+      "integrity": "sha512-GA976JLtnTK4xvDYYuUnAKkByonWO7Nsu8roK1RQ7DMxk8dfC9/vbFidxsaFq3oeFAY2OfTsqtCDdXhwcPxofA==",
       "dev": true,
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -16419,13 +16435,13 @@
       }
     },
     "@dotcom-tool-kit/types": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/types/-/types-3.4.1.tgz",
-      "integrity": "sha512-laZf+QpC8WZ02zep4bKU+tk0bfO0fEXIKUNfw6rTzkk2XctaLPj9PcKYqVq3EGPE3Sc/wpqwBkspVrhfEN4xXA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/types/-/types-3.5.0.tgz",
+      "integrity": "sha512-xmQHpqF4nRifgYXpgWkPUsW3GyhzcVR5qNcSjknZTF7ETsnlOWcKRl28VRZFL9FMn8fR5ftq/LgBq0jtvFaiKg==",
       "dev": true,
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
-        "@dotcom-tool-kit/logger": "^3.3.0",
+        "@dotcom-tool-kit/logger": "^3.3.1",
         "semver": "^7.3.7",
         "tslib": "^2.3.1",
         "zod": "^3.20.2"
@@ -20387,6 +20403,12 @@
       "requires": {
         "ms": "^2.0.0"
       }
+    },
+    "husky": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/plugin-transform-react-jsx": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
     "@dotcom-tool-kit/component": "^4.0.4",
-    "@dotcom-tool-kit/jest": "^3.2.2",
+    "@dotcom-tool-kit/jest": "^3.3.0",
     "@dotcom-tool-kit/logger": "^3.3.0",
     "@dotcom-tool-kit/node": "^3.3.8",
     "@dotcom-tool-kit/pa11y": "^0.5.0",
@@ -33,6 +33,7 @@
     "check-engine": "^1.10.1",
     "dotcom-tool-kit": "^3.3.9",
     "expect.js": "^0.3.1",
+    "husky": "^8.0.3",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "pa11y-ci": "^3.0.1",
@@ -72,7 +73,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "PA11Y=true npm run start"
+      "pre-push": "npm run test"
     }
   },
   "volta": {


### PR DESCRIPTION
## Description

This PR is to migrate to doppler from vault within toolkit. The vault settings in `.toolkitrc.yml` are replaced by those for doppler. Since there is no system name for `n-live-chat` in biz-ops, project name becomes `repo_n-live-chat` (It is reflected in the [doppler dashboard](https://dashboard.doppler.com/workplace/99fbb11f5bea112e94dd/projects/repo_n-live-chat) as well)

Because pa11y has been [advised against](https://github.com/Financial-Times/dotcom-tool-kit/tree/main/plugins/pa11y?rgh-link-date=2023-12-19T10%3A36%3A51Z#deprecation-warning-04102023) and the current way to run pa11y tests on CI is unorthodox, the pa11y tests are removed. Unit tests are run on CI instead.

## Changes

- replace vault with doppler in toolkit
- remove pa11y tests from CI jobs
- add Jest unit tests to CI jobs