### PR TITLE
ADSDEV-2011: upgrading nodejs version to 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,8 @@
         "webpack-cli": "^5.0.0"
       },
       "engines": {
-        "node": "16.x || 18.x",
-        "npm": "7.x || 8.x || 9.x"
+        "node": "20.x",
+        "npm": "10.x"
       },
       "peerDependencies": {
         "@financial-times/o-buttons": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -77,11 +77,11 @@
     }
   },
   "volta": {
-    "node": "18.17.0"
+    "node": "20.17.0"
   },
   "engines": {
-    "node": "16.x || 18.x",
-    "npm": "7.x || 8.x || 9.x"
+    "node": "20.x",
+    "npm": "10.x"
   },
   "overrides": {
     "typescript": "^5.0.4"


### PR DESCRIPTION
## Description
Updates Node.js version to 20.

## Implementation
TLDR This PR updates package.json and package-lock.json to use Node.js 20.

## Notes
Jira Ticket: [ADSDEV-2011](https://financialtimes.atlassian.net/browse/ADSDEV-2011)

[ADSDEV-2011]: https://financialtimes.atlassian.net/browse/ADSDEV-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ